### PR TITLE
Express 3.0 Compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,8 @@
  
 var express = require('express'),
     path = require('path'),
-    lingo = require('lingo');
+    lingo = require('lingo'),
+    HTTPMethods = require('methods').concat('del');
 
 /**
  * Pre-defined action ordering.
@@ -31,12 +32,6 @@ var orderedActions = [
   'update',
   'destroy'
 ];
-
-/**
- * HTTP Methods
- */
-
-var HTTPMethods = express.router.methods.concat('del');
 
 /**
  * Extend function.
@@ -377,5 +372,14 @@ var methods = {
 };
 
 // Load `methods` onto the server prototypes
-$(express.HTTPServer.prototype, methods);
-$(express.HTTPSServer.prototype, methods);
+// Express 2.x
+if (express.HTTPServer) {
+  $(express.HTTPServer.prototype, methods);
+}
+if (express.HTTPSServer) {
+  $(express.HTTPSServer.prototype, methods);
+}
+// Express 3.x
+if (express.application) {
+  $(express.application, methods);
+}

--- a/package.json
+++ b/package.json
@@ -7,10 +7,13 @@
     "url": "https://github.com/tpeden/express-resource-new"
   },
   "author": "TJ Peden <tj.peden@tj-coding.com>",
-  "dependencies": { "lingo": ">=0.0.4" },
+  "dependencies": { 
+    "lingo": ">=0.0.4",
+    "methods": "0.0.1"
+  },
   "devDependencies": {
     "connect": "*",
-    "express": "2.x",
+    "express": "3.x",
     "mocha": "*",
     "should": "*"
   },


### PR DESCRIPTION
As requested, here's a pull request. Wasn't sure what to have the express dependency as, so I left it at 3.x as I've been using. 
