### PR TITLE
Bind the controller to each resource-callback to allow passing a class i...

### DIFF
--- a/index.js
+++ b/index.js
@@ -156,7 +156,7 @@ $(Resource.prototype, {
         before = [].concat(self.before[action]);
       }
       
-      self._map(method, path, before, callback)
+      self._map(method, path, before, callback.bind(actions))
         ._record(action, method, path);
     });
   },


### PR DESCRIPTION
...nstance as a controller.

This patch allows passing a class-instance as a controller. Consider the following pseudocode as an example:

`Controller.js`:

``` js
function Controller(Model) {
  this.Model = Model;
}

Controller.prototype.index = function(req, res, next) {
  this.Model.find(function(err, entries) {
    if (err) return next(err);

    res.send(entries);
  }
}
```

then in `controllers/users/index.js`:

``` js
var Controller = require('../Controller.js');

module.exports = (function() { return new Controller(UserModel) })();
```

Personally I have my own controller initialization logic and I overwrite the `app._load()` method to inject my controller instances.

Let me know what you think!
