### PR TITLE
Fix for parameter names containing slash

### DIFF
--- a/index.js
+++ b/index.js
@@ -168,8 +168,9 @@ $(Resource.prototype, {
    */
   
   _defaultId: function() {
+    var resourceName = this.name.match(/(?:\S+\/)?(\S+)/)[1];
     return this.root ?
-      'id' : lingo.en.singularize(this.name);
+      'id' : lingo.en.singularize(resourceName);
   },
   
   /**

--- a/test/controllers/admin/users.js
+++ b/test/controllers/admin/users.js
@@ -1,0 +1,23 @@
+module.exports = {
+  index: function(request, response) {
+    response.send('users index');
+  },
+  show: function(request, response) {
+    response.send('show user ' + request.params.user);
+  },
+  new: function(request, response) {
+    response.send('new user');
+  },
+  create: function(request, response) {
+    response.send('create user');
+  },
+  edit: function(request, response) {
+    response.send('edit user ' + request.params.user);
+  },
+  update: function(request, response) {
+    response.send('update user ' + request.params.user);
+  },
+  destroy: function(request, response) {
+    response.send('delete user ' + request.params.user);
+  }
+};

--- a/test/other_tests.js
+++ b/test/other_tests.js
@@ -1,7 +1,7 @@
 var express = require('express'),
     Resource = require('../');
 
-var app = express.createServer();
+var app = express();
 
 app.configure(function(){
   app.set('controllers', __dirname + '/controllers');

--- a/test/resource_spec.js
+++ b/test/resource_spec.js
@@ -7,7 +7,7 @@ describe("app.resource", function() {
   var app;
   
   beforeEach(function() {
-    app = express.createServer();
+    app = express();
 
     app.configure(function(){
       app.set('controllers', __dirname + '/controllers');

--- a/test/resource_spec.js
+++ b/test/resource_spec.js
@@ -114,5 +114,12 @@ describe("app.resource", function() {
     resource.routes[6].path.should.equal("/:id.:format?");
   });
   
-  it("should respond with correct action");
+  it("should not generate parameter names with slash", function() {
+    var resource = app.resource('admin/users');
+
+    resource.routes[3].path.should.equal("/admin/users/:user.:format?");
+    resource.routes[4].path.should.equal("/admin/users/:user/edit.:format?");
+    resource.routes[5].path.should.equal("/admin/users/:user.:format?");
+    resource.routes[6].path.should.equal("/admin/users/:user.:format?");
+  });
 });


### PR DESCRIPTION
Hi,

I'm grouping my controller/resouces into subfolders which got me into trouble. 

Something like

``` javascript
app.resource('admin/users');
```

would result in default id-parameter `:admin/user` which is not a valid parameter name.

My commit fixes this by using the last part of the resource name as parameter (ie `:user`), instead of the whole resource name.

Replaced express.createServer() with express() along the way to get rid of deprecation warnings aswell.
