### PR TITLE
Custom routes registered first, so collection are not overriden by the show default route

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@ function httpMethod(self, method, base) {
     path += action + ".:format?";
       
     if(self.before && action in self.before) {
-      before = self.before[action];
+      before = [].concat(self.before[action]);
     }
     
     self._map(method, path, before, callback)

--- a/index.js
+++ b/index.js
@@ -114,13 +114,21 @@ var Resource = module.exports = function Resource(app, name, options) {
 $(Resource.prototype, {
   
   /**
-   * Configure the default actions.
+   * initialize the resource object.
    * 
    * @param {Object} actions
    */
   
   _init: function(actions) {
     this.actions = actions;
+  },
+
+  /**
+   * Configure the default actions.
+   *
+   */
+
+  _defaultMapping: function(){
     var self = this;
     
     orderedActions.forEach(function(action) {
@@ -366,6 +374,7 @@ var methods = {
     if('function' == typeof callback) {
       resource._nest(callback);
     }
+    resource._defaultMapping();
     
     return resource;
   }

--- a/test/resource_spec.js
+++ b/test/resource_spec.js
@@ -7,7 +7,7 @@ describe("app.resource", function() {
   var app;
   
   beforeEach(function() {
-    app = express.createServer();
+    app = express();
 
     app.configure(function(){
       app.set('controllers', __dirname + '/controllers');
@@ -30,8 +30,8 @@ describe("app.resource", function() {
       comments = app.resource('comments');
     });
     
-    app.resources.should.be.a('object').and.have.property('articles', articles);
-    app.resources.should.be.a('object').and.have.property('article_comments', comments);
+    app.resources.should.be.an.Object.and.have.property('articles', articles);
+    app.resources.should.be.an.Object.and.have.property('article_comments', comments);
   });
   
   it("should create all the appropriate routes for a resource", function() {
@@ -86,9 +86,9 @@ describe("app.resource", function() {
       });
     });
     
-    articles.routes[7].path.should.equal("/articles/:article/bonus.:format?");
-    comments.routes[7].path.should.equal("/articles/:article/comments/search.:format?");
-    comments.routes[8].path.should.equal("/articles/:article/comments/:comment/reply.:format?");
+    articles.routes[0].path.should.equal("/articles/:article/bonus.:format?");
+    comments.routes[0].path.should.equal("/articles/:article/comments/search.:format?");
+    comments.routes[1].path.should.equal("/articles/:article/comments/:comment/reply.:format?");
   });
   
   it("should allow deep nesting", function() {
@@ -114,5 +114,5 @@ describe("app.resource", function() {
     resource.routes[6].path.should.equal("/:id.:format?");
   });
   
-  it("should respond with correct action");
+  //it("should respond with correct action");
 });


### PR DESCRIPTION
```
  comments = this.resource('comments', function() {
    this.collection.get('search');
    this.member.get('reply');
  });
```

the 'search' action was registered after the default mapping, so comments/search was redirected to the comment's show action with search as id, and never reached the 'search' custom action.

This pull request makes sure that the custom actions are registered first and thus not caught be the default mapping

It also corrects a bug that made the "before" option not working on custom actions
